### PR TITLE
added permission to DELETE DBClusterSnapshots.

### DIFF
--- a/infrastructure/src/rds-cross-region-backup.py
+++ b/infrastructure/src/rds-cross-region-backup.py
@@ -134,6 +134,7 @@ backup_rds_role = template.add_resource(iam.Role(
                     aws.Action('rds', 'DescribeDbSnapshots'),
                     aws.Action('rds', 'CopyDbSnapshot'),
                     aws.Action('rds', 'DeleteDbSnapshot'),
+                    aws.Action('rds', 'DeleteDbClusterSnapshot'),
                     aws.Action('rds', 'DescribeDbClusters'),
                     aws.Action('rds', 'DescribeDbClusterSnapshots'),
                     aws.Action('rds', 'CopyDBClusterSnapshot'),

--- a/infrastructure/templates/rds-cross-region-backup.json
+++ b/infrastructure/templates/rds-cross-region-backup.json
@@ -238,6 +238,7 @@
                                         "rds:DescribeDbSnapshots",
                                         "rds:CopyDbSnapshot",
                                         "rds:DeleteDbSnapshot",
+                                        "rds:DeleteDbClusterSnapshot",
                                         "rds:DescribeDbClusters",
                                         "rds:DescribeDbClusterSnapshots",
                                         "rds:CopyDBClusterSnapshot"


### PR DESCRIPTION
Without this permission, the lambda starts failing after the first of several DBClusters, because of not being able to purge older snapshots for the first DBCluster.